### PR TITLE
feat: add held message storage and admin processing for maintenance mode

### DIFF
--- a/apps/backend/src/conversation/handler.ts
+++ b/apps/backend/src/conversation/handler.ts
@@ -21,7 +21,7 @@ import { sendBundleImages } from "./images.ts";
 import { trackEvent } from "../domains/analytics/index.ts";
 
 const RESPONSE_DELAY_MS = parseInt(
-  process.env.BOT_RESPONSE_DELAY_MS || "4000",
+  process.env.BOT_RESPONSE_DELAY_MS || "3000",
   10,
 );
 const BACKLOG_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes

--- a/apps/backend/src/conversation/index.ts
+++ b/apps/backend/src/conversation/index.ts
@@ -7,7 +7,4 @@ export {
   isSessionTimedOut,
 } from "./store.ts";
 export { holdMessage, countHeldMessages } from "./held-messages.ts";
-export {
-  processHeldMessages,
-  getPendingCount as getPendingHeldCount,
-} from "./process-held.ts";
+export { processHeldMessages } from "./process-held.ts";

--- a/apps/backend/src/conversation/process-held.ts
+++ b/apps/backend/src/conversation/process-held.ts
@@ -1,55 +1,74 @@
 import {
-  getHeldMessages,
   clearHeldMessages,
-  countHeldMessages,
+  getAggregatedHeldMessages,
 } from "./held-messages.ts";
 import { handleMessage } from "./handler.ts";
 
 /**
  * Process all held messages from maintenance mode
- * @returns Number of messages processed
+ *
+ * Groups messages by user and aggregates them
+ * to ensure the state machine processes all user context at once.
+ *
+ * @returns Number of users processed
  */
-export async function processHeldMessages(): Promise<number> {
-  const heldMessages = getHeldMessages();
+export async function processHeldMessages(): Promise<{
+  usersProcessed: number;
+  messagesProcessed: number;
+  errors: number;
+}> {
+  const aggregatedGroups = getAggregatedHeldMessages();
 
-  if (heldMessages.length === 0) {
-    return 0;
+  if (aggregatedGroups.length === 0) {
+    return { usersProcessed: 0, messagesProcessed: 0, errors: 0 };
   }
 
-  console.log(`[HeldMessages] Processing ${heldMessages.length} held messages`);
+  console.log(
+    `[HeldMessages] Processing ${aggregatedGroups.length} users with held messages`,
+  );
 
   const processedIds: number[] = [];
+  let errorCount = 0;
 
-  for (const msg of heldMessages) {
+  for (const group of aggregatedGroups) {
     try {
+      console.log(
+        `[HeldMessages] Processing ${group.message_count} messages for ${group.phone_number}`,
+      );
+
+      // Process all messages for this user at once
       await handleMessage({
-        phoneNumber: msg.phone_number,
-        content: msg.message_text,
-        timestamp: msg.whatsapp_timestamp,
-        messageId: msg.message_id,
+        phoneNumber: group.phone_number,
+        content: group.aggregated_text,
+        timestamp: group.oldest_timestamp,
+        messageId: group.latest_message_id,
       });
 
-      processedIds.push(msg.id);
+      // Track IDs for cleanup
+      const ids = group.message_ids.split(",").map((id) => parseInt(id, 10));
+      processedIds.push(...ids);
     } catch (error) {
+      errorCount++;
       console.error(
-        `[HeldMessages] Failed to process message ${msg.id} from ${msg.phone_number}:`,
+        `[HeldMessages] Failed to process messages for ${group.phone_number}:`,
         error,
       );
-      // Continue with next message, don't mark this one as processed
+      // Continue with next user, don't mark failed ones as processed
     }
   }
 
-  // Clear processed messages
+  // Clear successfully processed messages
   if (processedIds.length > 0) {
     clearHeldMessages(processedIds);
   }
 
-  return processedIds.length;
-}
+  const result = {
+    usersProcessed: aggregatedGroups.length - errorCount,
+    messagesProcessed: processedIds.length,
+    errors: errorCount,
+  };
 
-/**
- * Get count of pending held messages
- */
-export function getPendingCount(): number {
-  return countHeldMessages();
+  console.log(`[HeldMessages] Completed:`, result);
+
+  return result;
 }

--- a/apps/backend/src/db/schema.sql
+++ b/apps/backend/src/db/schema.sql
@@ -121,6 +121,15 @@ CREATE TABLE IF NOT EXISTS message_inbox (
     processed_at INTEGER
 );
 
+CREATE TABLE IF NOT EXISTS held_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    phone_number TEXT NOT NULL,
+    message_text TEXT NOT NULL,
+    message_id TEXT UNIQUE NOT NULL,
+    whatsapp_timestamp INTEGER NOT NULL,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch('now', 'subsec') * 1000)
+);
+
 CREATE TABLE IF NOT EXISTS audit_log (
     id TEXT PRIMARY KEY,
     user_id TEXT NOT NULL REFERENCES users(id),
@@ -198,6 +207,7 @@ CREATE INDEX IF NOT EXISTS idx_orders_conversation ON orders(conversation_phone)
 CREATE INDEX IF NOT EXISTS idx_orders_agent ON orders(assigned_agent);
 CREATE INDEX IF NOT EXISTS idx_conversations_assigned ON conversations(assigned_agent);
 CREATE INDEX IF NOT EXISTS idx_users_available ON users(role, is_available, is_active);
+CREATE INDEX IF NOT EXISTS idx_held_messages_phone ON held_messages(phone_number, created_at ASC);
 CREATE INDEX IF NOT EXISTS idx_message_inbox_pending ON message_inbox(status, phone_number, created_at);
 CREATE INDEX IF NOT EXISTS idx_llm_errors_phone ON llm_error_log(phone_number, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_llm_errors_type ON llm_error_log(error_type, created_at DESC);


### PR DESCRIPTION
* Add held_messages database table with indexes for per-user and time-based retrieval.
* Aggregate held messages by user and process them in batches after maintenance, returning detailed processing statistics.
* Add admin API endpoints to query pending held message counts and trigger processing.
* Update admin dashboard to display held message counts, allow manual processing, and show processing status.
* Reduce default bot response delay to improve responsiveness.
* Remove unused backend exports related to pending message counts.