### PR TITLE
refactor(urls): centralize service URL resolution via shared utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,21 +2,15 @@
 NODE_ENV=development
 LOG_LEVEL=debug
 
-# SERVICES (ports in sequence: 3000, 3001, 5173)
+# SERVICE PORTS
 PORT=3000
 NOTIFIER_PORT=3001
-FRONTEND_URL=http://localhost:5173
 
 # BACKEND
 DB_PATH=./data/database.sqlite
 UPLOAD_DIR=./data/uploads
 JWT_SECRET=
-PUBLIC_URL=http://localhost:3000
-
-# NOTIFIER (whatsapp-web.js for dev, team notifications in prod)
-NOTIFIER_URL=http://localhost:3001
 NOTIFIER_DATA_PATH=./data/notifier
-BACKEND_URL=http://localhost:3000
 
 # WhatsApp groups (optional, can be auto-registered with @activate)
 WHATSAPP_GROUP_AGENT=
@@ -41,3 +35,6 @@ POWERBI_MODEL_ID=
 
 # LLM
 GEMINI_API_KEY=
+
+# PRODUCTION ONLY (optional overrides)
+# PUBLIC_URL=https://{URL}

--- a/apps/backend/src/adapters/notifier/client.ts
+++ b/apps/backend/src/adapters/notifier/client.ts
@@ -1,9 +1,9 @@
-import process from "node:process";
 import { createLogger } from "../../lib/logger.ts";
+import { getNotifierUrl } from "@totem/utils";
 
 const logger = createLogger("notifier");
 
-const NOTIFIER_URL = process.env.NOTIFIER_URL || "http://localhost:3001";
+const notifierUrl = getNotifierUrl();
 
 type NotifyRequest = {
   channel: "agent" | "dev" | "sales";
@@ -15,7 +15,7 @@ export async function notifyTeam(
   message: string,
 ): Promise<boolean> {
   try {
-    const response = await fetch(`${NOTIFIER_URL}/notify`, {
+    const response = await fetch(`${notifierUrl}/notify`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ channel, message } as NotifyRequest),
@@ -30,7 +30,7 @@ export async function notifyTeam(
 
 export async function checkNotifierHealth(): Promise<boolean> {
   try {
-    const response = await fetch(`${NOTIFIER_URL}/health`, {
+    const response = await fetch(`${notifierUrl}/health`, {
       method: "GET",
     });
     return response.ok;

--- a/apps/backend/src/adapters/whatsapp/dev-adapter.ts
+++ b/apps/backend/src/adapters/whatsapp/dev-adapter.ts
@@ -1,16 +1,16 @@
-import process from "node:process";
 import type { WhatsAppAdapter } from "./types.ts";
 import { createLogger } from "../../lib/logger.ts";
+import { getNotifierUrl, getPublicUrl } from "@totem/utils";
 
 const logger = createLogger("whatsapp");
 
-const NOTIFIER_URL = process.env.NOTIFIER_URL || "http://localhost:3001";
-const PUBLIC_URL = process.env.PUBLIC_URL || "http://localhost:3000";
+const notifierUrl = getNotifierUrl();
+const publicUrl = getPublicUrl();
 
 export const DevAdapter: WhatsAppAdapter = {
   async sendMessage(to: string, content: string): Promise<string | null> {
     try {
-      const response = await fetch(`${NOTIFIER_URL}/send`, {
+      const response = await fetch(`${notifierUrl}/send`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phoneNumber: to, content }),
@@ -41,10 +41,10 @@ export const DevAdapter: WhatsAppAdapter = {
     imagePath: string,
     caption?: string,
   ): Promise<string | null> {
-    const imageUrl = `${PUBLIC_URL}/static/${imagePath}`;
+    const imageUrl = `${publicUrl}/static/${imagePath}`;
 
     try {
-      const response = await fetch(`${NOTIFIER_URL}/send-image`, {
+      const response = await fetch(`${notifierUrl}/send-image`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phoneNumber: to, imageUrl, caption }),

--- a/apps/backend/src/domains/conversations/assignment.ts
+++ b/apps/backend/src/domains/conversations/assignment.ts
@@ -1,6 +1,6 @@
 import { db } from "../../db/index.ts";
 import { createLogger } from "../../lib/logger.ts";
-import { getFrontendUrl } from "@totem/utils";
+import { getFrontendUrl, getNotifierUrl } from "@totem/utils";
 
 const logger = createLogger("assignment");
 
@@ -85,7 +85,7 @@ async function sendAssignmentNotification(
     `Accede aquí: ${frontendUrl}/dashboard/conversations/${clientPhone}\n\n` +
     `Tienes 5 minutos para aceptar esta asignación.`;
 
-  const notifierUrl = process.env.NOTIFIER_URL || "http://localhost:3001";
+  const notifierUrl = getNotifierUrl();
 
   try {
     await fetch(`${notifierUrl}/notify`, {

--- a/apps/frontend/src/lib/utils/server-fetch.ts
+++ b/apps/frontend/src/lib/utils/server-fetch.ts
@@ -1,7 +1,9 @@
-const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3000";
+import { getBackendUrl as getBackendUrlUtil } from "@totem/utils";
+
+const backendUrlBase = getBackendUrlUtil();
 
 export function getBackendUrl(path: string): string {
-  return `${BACKEND_URL}${path}`;
+  return `${backendUrlBase}${path}`;
 }
 
 export async function fetchBackend(

--- a/apps/frontend/src/routes/webhook/+server.ts
+++ b/apps/frontend/src/routes/webhook/+server.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "./$types";
+import { getBackendUrl } from "@totem/utils";
 
-const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3000";
+const backendUrl = getBackendUrl();
 
 /**
  * GET /webhook (Meta webhook verification)
@@ -9,7 +10,7 @@ const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3000";
 export const GET: RequestHandler = async ({ url }) => {
   try {
     const params = url.searchParams.toString();
-    const response = await fetch(`${BACKEND_URL}/webhook?${params}`, {
+    const response = await fetch(`${backendUrl}/webhook?${params}`, {
       method: "GET",
     });
 
@@ -31,7 +32,7 @@ export const POST: RequestHandler = async ({ request }) => {
     const body = await request.text();
 
     // Fire and forget
-    fetch(`${BACKEND_URL}/webhook`, {
+    fetch(`${backendUrl}/webhook`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,1 +1,6 @@
-export { getFrontendUrl, getBackendUrl, getPublicUrl } from "./url.ts";
+export {
+  getFrontendUrl,
+  getBackendUrl,
+  getPublicUrl,
+  getNotifierUrl,
+} from "./url.ts";

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -18,28 +18,67 @@ function readTunnelUrl(): string | null {
 }
 
 /**
- * Get frontend URL (for links to dashboard).
+ * Get the publicly accessible frontend URL.
  *
- * Priority: .cloudflare-url > FRONTEND_URL > localhost:5173
+ * Used for:
+ * - Clickable links in WhatsApp notifications (agent assignments, contract uploads)
+ * - CORS origin validation in backend
+ *
+ * Priority: .cloudflare-url > http://localhost:5173
+ *
+ * In development, this returns the Cloudflare tunnel URL that exposes the frontend.
  */
 export function getFrontendUrl(): string {
-  return readTunnelUrl() ?? process.env.FRONTEND_URL ?? "http://localhost:5173";
+  return readTunnelUrl() ?? "http://localhost:5173";
 }
 
 /**
- * Get backend URL (for API calls from frontend/notifier).
+ * Get the backend URL for server-to-server communication.
  *
- * Priority: .cloudflare-url > BACKEND_URL > localhost:3000
+ * Used for:
+ * - Notifier forwarding messages to backend /webhook endpoint
+ * - Frontend SSR calling backend API endpoints
+ * - Frontend webhook proxy calling backend
+ *
+ * Constructs URL from PORT environment variable.
  */
 export function getBackendUrl(): string {
-  return readTunnelUrl() ?? process.env.BACKEND_URL ?? "http://localhost:3000";
+  const port = process.env.PORT ?? "3000";
+  return `http://localhost:${port}`;
 }
 
 /**
- * Get public URL (for static assets accessible from WhatsApp).
+ * Get the public URL for static assets accessible from external services.
  *
- * Priority: .cloudflare-url > PUBLIC_URL > localhost:3000
+ * Used for:
+ * - WhatsApp Cloud API image URLs (images sent to users)
+ *
+ * Priority: .cloudflare-url > http://localhost:{PORT}
+ *
+ * In development, this returns the Cloudflare tunnel URL. Vite proxies
+ * /static/* requests to the backend, making images accessible to WhatsApp.
+ * In production, this should be explicitly set via PUBLIC_URL env var.
  */
 export function getPublicUrl(): string {
-  return readTunnelUrl() ?? process.env.PUBLIC_URL ?? "http://localhost:3000";
+  const tunnelUrl = readTunnelUrl();
+  if (tunnelUrl) return tunnelUrl;
+
+  if (process.env.PUBLIC_URL) return process.env.PUBLIC_URL;
+
+  const port = process.env.PORT ?? "3000";
+  return `http://localhost:${port}`;
+}
+
+/**
+ * Get the notifier service URL for backend-to-notifier communication.
+ *
+ * Used for:
+ * - Backend sending direct messages via notifier
+ * - Backend notifying teams via notifier
+ *
+ * Constructs URL from NOTIFIER_PORT environment variable.
+ */
+export function getNotifierUrl(): string {
+  const port = process.env.NOTIFIER_PORT ?? "3001";
+  return `http://localhost:${port}`;
 }


### PR DESCRIPTION
Refactor how backend, frontend, notifier, and public service URLs are constructed and consumed across the codebase. URL resolution is now centralized in @totem/utils to eliminate scattered environment variable usage and ensure consistent behavior across environments, including local development with tunnels.

* Add getNotifierUrl and standardize getFrontendUrl, getBackendUrl, and getPublicUrl in packages/utils.
* Replace direct environment variable usage with shared URL helpers in backend adapters, domain logic, frontend server fetch utilities, and webhook routes.
* Update utils exports to expose the new URL helpers.
* Clean up .env.example by removing unused variables and clarifying production-only overrides.