### PR TITLE
conversations: add DNI eligibility retry flow with attempt tracking

### DIFF
--- a/packages/core/src/conversation/phases/collecting-dni.ts
+++ b/packages/core/src/conversation/phases/collecting-dni.ts
@@ -8,13 +8,32 @@ import * as T from "../../templates/standard.ts";
 
 export function transitionCollectingDni(
   message: string,
-  _metadata: ConversationMetadata,
+  metadata: ConversationMetadata,
 ): TransitionResult {
   const dni = extractDNI(message);
   const lower = message.toLowerCase();
 
   if (dni) {
-    // Valid DNI, request provider check
+    const triedDnis = metadata.triedDnis || [];
+    if (triedDnis.includes(dni)) {
+      // DNI already attempted, ask for a different one
+      const { message: messages } = selectVariant(
+        T.DNI_ALREADY_TRIED,
+        "DNI_ALREADY_TRIED",
+        {},
+      );
+
+      return {
+        type: "update",
+        nextPhase: { phase: "collecting_dni" },
+        commands: messages.map((text) => ({
+          type: "SEND_MESSAGE" as const,
+          text,
+        })),
+      };
+    }
+
+    // Valid DNI not tried before, request provider check
     return {
       type: "need_enrichment",
       enrichment: { type: "check_eligibility", dni },

--- a/packages/core/src/conversation/phases/offering-dni-retry.ts
+++ b/packages/core/src/conversation/phases/offering-dni-retry.ts
@@ -1,0 +1,101 @@
+import type { ConversationMetadata, TransitionResult } from "../types.ts";
+import { selectVariant } from "../../messaging/variation-selector.ts";
+import { extractDNI } from "../../validation/regex.ts";
+import * as T from "../../templates/standard.ts";
+
+type OfferingDniRetryPhase = Extract<
+  import("../types.ts").ConversationPhase,
+  { phase: "offering_dni_retry" }
+>;
+
+export function transitionOfferingDniRetry(
+  phase: OfferingDniRetryPhase,
+  message: string,
+  metadata: ConversationMetadata,
+): TransitionResult {
+  const lower = message.toLowerCase().trim();
+
+  const attemptCount = (metadata.triedDnis?.length || 0) + 1;
+
+  const dni = extractDNI(message);
+  if (dni) {
+    // Transition to collecting_dni phase which will handle deduplication
+    return {
+      type: "update",
+      nextPhase: { phase: "collecting_dni" },
+      commands: [],
+    };
+  }
+
+  // User explicitly declines retry
+  const isNegative =
+    /^(no|nop|nope|negativo|nada|no\s+tengo|ya\s+no)$/i.test(lower) ||
+    /\b(no\s+quiero|no\s+tengo|no\s+puedo)\b/.test(lower);
+
+  if (isNegative) {
+    const { message: messages } = selectVariant(
+      [
+        ["Entiendo. Si en el futuro cambias de opinión, aquí estaré 😊"],
+        [
+          "Está bien. Gracias por tu tiempo. Cualquier cosa, nos vuelves a escribir.",
+        ],
+        [
+          "Sin problema. Si más adelante quieres revisar otra opción, no dudes en contactarnos.",
+        ],
+      ],
+      "DNI_RETRY_DECLINED",
+      {},
+    );
+
+    return {
+      type: "update",
+      nextPhase: { phase: "closing", purchaseConfirmed: false },
+      commands: [
+        {
+          type: "TRACK_EVENT",
+          event: "dni_retry_declined",
+          metadata: { attemptCount },
+        },
+        ...messages.map((text) => ({ type: "SEND_MESSAGE" as const, text })),
+      ],
+    };
+  }
+
+  // User accepts (positive response)
+  const isPositive =
+    /^(s[ií]|sip|claro|ok|okey|vale|dale|bueno|perfecto)$/i.test(lower) ||
+    /\bquiero\b|\btengo\b|\bpuedo\b/.test(lower);
+
+  if (isPositive) {
+    const { message: messages } = selectVariant(
+      T.CONFIRM_CLIENT_YES,
+      "ASK_DNI_RETRY",
+      {},
+    );
+
+    return {
+      type: "update",
+      nextPhase: { phase: "collecting_dni" },
+      commands: messages.map((text) => ({
+        type: "SEND_MESSAGE" as const,
+        text,
+      })),
+    };
+  }
+
+  // For acknowledgment or unclear responses, re-prompt
+  const { message: messages } = selectVariant(
+    T.OFFER_DNI_RETRY,
+    "OFFER_DNI_RETRY_REPROMPT",
+    {},
+  );
+
+  return {
+    type: "update",
+    nextPhase: phase,
+    commands: messages.map((text) => ({
+      type: "SEND_MESSAGE" as const,
+      text,
+    })),
+  };
+}

--- a/packages/core/src/conversation/transition.ts
+++ b/packages/core/src/conversation/transition.ts
@@ -3,6 +3,7 @@ import { transitionGreeting } from "./phases/greeting.ts";
 import { transitionConfirmingClient } from "./phases/confirming-client.ts";
 import { transitionCollectingDni } from "./phases/collecting-dni.ts";
 import { transitionCheckingEligibility } from "./phases/checking-eligibility.ts";
+import { transitionOfferingDniRetry } from "./phases/offering-dni-retry.ts";
 import { transitionCollectingAge } from "./phases/collecting-age.ts";
 import { transitionOfferingProducts } from "./phases/offering-products.ts";
 import { transitionHandlingObjection } from "./phases/handling-objection.ts";
@@ -23,7 +24,15 @@ export function transition(input: TransitionInput): TransitionResult {
       return transitionCollectingDni(message, metadata);
 
     case "checking_eligibility":
-      return transitionCheckingEligibility(phase, message, enrichment);
+      return transitionCheckingEligibility(
+        phase,
+        message,
+        metadata,
+        enrichment,
+      );
+
+    case "offering_dni_retry":
+      return transitionOfferingDniRetry(phase, message, metadata);
 
     case "collecting_age":
       return transitionCollectingAge(phase, message, metadata);

--- a/packages/core/src/conversation/types.ts
+++ b/packages/core/src/conversation/types.ts
@@ -5,6 +5,7 @@ export type ConversationPhase =
   | { phase: "confirming_client" }
   | { phase: "collecting_dni" }
   | { phase: "checking_eligibility"; dni: string }
+  | { phase: "offering_dni_retry" }
   | {
       phase: "collecting_age";
       dni: string;
@@ -74,6 +75,7 @@ export type ConversationMetadata = {
   age?: number;
   lastCategory?: string;
   isReturningUser?: boolean;
+  triedDnis?: string[];
   createdAt: number;
   lastActivityAt: number;
 };

--- a/packages/core/src/templates/standard.ts
+++ b/packages/core/src/templates/standard.ts
@@ -88,3 +88,33 @@ export const DNI_WAITING = {
     ["Con calma, no hay prisa."],
   ],
 };
+
+export const OFFER_DNI_RETRY = [
+  [
+    "No encontramos línea disponible para ese DNI. ¿Quieres intentar con otro DNI de alguien que viva contigo?",
+  ],
+  [
+    "Lamentablemente ese DNI no tiene línea disponible. Si vives con alguien más, puedes intentar con su DNI.",
+  ],
+  [
+    "Ese DNI no califica por ahora. ¿Tienes otro DNI que quieras revisar? Puede ser de un familiar que viva contigo.",
+  ],
+];
+
+export const DNI_ALREADY_TRIED = [
+  ["Ese DNI ya lo revisamos. ¿Tienes otro que quieras intentar?"],
+  ["Ya verificamos ese DNI. ¿Quieres probar con otro?"],
+  ["Ese número ya lo consultamos. ¿Tienes un DNI diferente?"],
+];
+
+export const MAX_ATTEMPTS_REACHED = [
+  [
+    "Ya revisamos varios DNIs y lamentablemente no encontramos líneas disponibles por el momento. ¡Gracias por tu interés! 😔",
+  ],
+  [
+    "Revisamos las opciones disponibles pero no encontramos línea de crédito. Te agradecemos por contactarnos.",
+  ],
+  [
+    "Desafortunadamente no podemos proceder en este momento. Si tienes dudas, vuelve a escribirnos. 😔",
+  ],
+];

--- a/packages/core/tests/conversation-transitions.test.ts
+++ b/packages/core/tests/conversation-transitions.test.ts
@@ -428,7 +428,7 @@ describe("Conversation transitions (checking eligibility phase)", () => {
     }
   });
 
-  test("should close when customer is not eligible", () => {
+  test("should offer DNI retry when customer is not eligible (first attempt)", () => {
     const enrichment: EnrichmentResult = {
       type: "eligibility_result",
       status: "not_eligible",
@@ -443,10 +443,7 @@ describe("Conversation transitions (checking eligibility phase)", () => {
 
     expect(result.type).toBe("update");
     if (result.type === "update") {
-      expect(result.nextPhase.phase).toBe("closing");
-      if (result.nextPhase.phase === "closing") {
-        expect(result.nextPhase.purchaseConfirmed).toBe(false);
-      }
+      expect(result.nextPhase.phase).toBe("offering_dni_retry");
     }
   });
 


### PR DESCRIPTION
* Add a new conversation phase to offer a DNI retry after an ineligible result and handle affirmative, negative, or unclear responses.
* Limit DNI eligibility attempts to three; close the conversation after the final failed attempt with an explicit message.
* Track previously attempted DNIs in conversation metadata and prevent duplicate retries.
* Update DNI collection logic to detect and reject already tried DNIs.
* Add new message templates for retry offers, duplicate DNI submissions, and max-attempts reached.
* Update types and expand tests to cover the new retry flow and state transitions.