### PR TITLE
feat(ui): make message ownership explicit and refactor simulator layout

### DIFF
--- a/apps/frontend/src/lib/components/conversations/message-bubble.svelte
+++ b/apps/frontend/src/lib/components/conversations/message-bubble.svelte
@@ -1,58 +1,66 @@
 <script lang="ts">
-	import { formatTime } from "$lib/utils/formatters";
-	import type { Snippet } from "svelte";
-	import type { MessageType } from "@totem/types";
+  import { formatTime } from "$lib/utils/formatters";
+  import type { Snippet } from "svelte";
+  import type { MessageType } from "@totem/types";
 
-	type Props = {
-		direction: "inbound" | "outbound";
-		type: MessageType;
-		content: string;
-		status?: string;
-		createdAt: string;
-		actions?: Snippet;
-	};
+  type Props = {
+    direction: "inbound" | "outbound";
+    type: MessageType;
+    content: string;
+    status?: string;
+    createdAt: string;
+    actions?: Snippet;
+    currentUserSide?: "inbound" | "outbound";
+  };
 
-	let { direction, type, content, status, createdAt, actions }: Props =
-		$props();
+  let {
+    direction,
+    type,
+    content,
+    status,
+    createdAt,
+    actions,
+    currentUserSide = "outbound",
+  }: Props = $props();
 
-	const isInbound = $derived(direction === "inbound");
+  const isMe = $derived(direction === currentUserSide);
 </script>
 
-<div class="flex {isInbound ? 'justify-end' : 'justify-start'} group">
-	<div
-		class="relative max-w-xl p-4 {isInbound
-			? 'bg-ink-900 text-cream-50'
-			: 'bg-white text-ink-900 border border-ink-900/10'}"
-	>
-		{#if actions}
-			<div
-				class="absolute -top-3 -right-3 opacity-0 group-hover:opacity-100 transition-opacity z-10"
-			>
-				{@render actions()}
-			</div>
-		{/if}
-		{#if type === "image"}
-			<img
-				src="/media/{content}"
-				alt="Imagen"
-				class="max-w-full h-auto mb-4 border border-ink-900/10"
-			/>
-		{:else}
-			<p
-				class="font-serif text-base leading-relaxed whitespace-pre-wrap {isInbound
-					? 'text-cream-50'
-					: 'text-ink-900'}"
-			>
-				{content}
-			</p>
-		{/if}
-		<span
-			class="text-[10px] font-mono uppercase tracking-widest block mt-2 {isInbound
-				? 'text-cream-50/40'
-				: 'text-ink-300'}"
-		>
-			{formatTime(createdAt)}{#if status}
-				• {status}{/if}
-		</span>
-	</div>
+<div class="flex {isMe ? 'justify-end' : 'justify-start'} group">
+  <div
+    class="relative max-w-xl p-4 {isMe
+      ? 'bg-ink-900 text-cream-50'
+      : 'bg-white text-ink-900 border border-ink-900/10'}"
+  >
+    {#if actions}
+      <div
+        class="absolute -top-3 -right-3 opacity-0 group-hover:opacity-100 transition-opacity z-10"
+      >
+        {@render actions()}
+      </div>
+    {/if}
+    {#if type === "image"}
+      <img
+        src="/media/{content}"
+        alt="Imagen"
+        class="max-w-full h-auto mb-4 border border-ink-900/10"
+      />
+    {:else}
+      <p
+        class="font-serif text-base leading-relaxed whitespace-pre-wrap {isMe
+          ? 'text-cream-50'
+          : 'text-ink-900'}"
+      >
+        {content}
+      </p>
+    {/if}
+    <span
+      class="text-[10px] font-mono uppercase tracking-widest block mt-2 {isMe
+        ? 'text-cream-50/40'
+        : 'text-ink-300'}"
+    >
+      {formatTime(createdAt)}{#if status}
+        • {status}{/if}
+    </span>
+  </div>
 </div>

--- a/apps/frontend/src/lib/components/conversations/message-thread.svelte
+++ b/apps/frontend/src/lib/components/conversations/message-thread.svelte
@@ -1,30 +1,34 @@
 <script lang="ts">
-import MessageBubble from "./message-bubble.svelte";
-import type { ConversationMessage } from "@totem/types";
+  import MessageBubble from "./message-bubble.svelte";
+  import type { ConversationMessage } from "@totem/types";
 
-type Props = {
-  messages: ConversationMessage[];
-};
+  type Props = {
+    messages: ConversationMessage[];
+    currentUserSide?: "inbound" | "outbound";
+  };
 
-let { messages }: Props = $props();
+  let { messages, currentUserSide = "outbound" }: Props = $props();
 </script>
 
 <div class="flex-1 overflow-y-auto p-8 space-y-4">
-	{#if messages.length === 0}
-		<div class="flex justify-center py-12">
-			<span class="text-xs text-ink-300 uppercase tracking-widest border-b border-ink-200 pb-1">
-				Inicio de conversación
-			</span>
-		</div>
-	{/if}
+  {#if messages.length === 0}
+    <div class="flex justify-center py-12">
+      <span
+        class="text-xs text-ink-300 uppercase tracking-widest border-b border-ink-200 pb-1"
+      >
+        Inicio de conversación
+      </span>
+    </div>
+  {/if}
 
-	{#each messages as msg (msg.id)}
-		<MessageBubble
-			direction={msg.direction}
-			type={msg.type}
-			content={msg.content}
-			status={msg.status}
-			createdAt={msg.created_at}
-		/>
-	{/each}
+  {#each messages as msg (msg.id)}
+    <MessageBubble
+      direction={msg.direction}
+      type={msg.type}
+      content={msg.content}
+      status={msg.status}
+      createdAt={msg.created_at}
+      {currentUserSide}
+    />
+  {/each}
 </div>

--- a/apps/frontend/src/routes/dashboard/simulator/+page.svelte
+++ b/apps/frontend/src/routes/dashboard/simulator/+page.svelte
@@ -1,631 +1,810 @@
 <script lang="ts">
-import { onMount } from "svelte";
-import { fetchApi } from "$lib/utils/api";
-import { formatPhone, formatPrice } from "$lib/utils/formatters";
-import Button from "$lib/components/ui/button.svelte";
-import Badge from "$lib/components/ui/badge.svelte";
-import MessageBubble from "$lib/components/conversations/message-bubble.svelte";
-import ConversationItem from "$lib/components/conversations/conversation-item.svelte";
-import PageTitle from "$lib/components/shared/page-title.svelte";
-import type { ReplayData, Conversation, TestPersona } from "@totem/types";
-import type { PageData } from "./$types";
+  import { onMount } from "svelte";
+  import { fetchApi } from "$lib/utils/api";
+  import { formatPhone, formatPrice } from "$lib/utils/formatters";
+  import Button from "$lib/components/ui/button.svelte";
+  import Badge from "$lib/components/ui/badge.svelte";
+  import MessageBubble from "$lib/components/conversations/message-bubble.svelte";
+  import ConversationItem from "$lib/components/conversations/conversation-item.svelte";
+  import PageTitle from "$lib/components/shared/page-title.svelte";
+  import type { ReplayData, Conversation, TestPersona } from "@totem/types";
+  import type { PageData } from "./$types";
 
-let { data }: { data: PageData } = $props();
+  let { data }: { data: PageData } = $props();
 
-let testConversations = $state<Conversation[]>([]);
-let personas = $state<TestPersona[]>([]);
-let selectedPersonaId = $state<string | null>(null);
-let selectedPhone = $state<string | null>(null);
-let showPersonaDialog = $state(false);
-let messages = $state<any[]>([]);
-let currentInput = $state("");
-let conversation = $state<any>(null);
-let loading = $state(false);
-let messagesContainer = $state<HTMLDivElement>();
-let polling: Timer | null = null;
+  let testConversations = $state<Conversation[]>([]);
+  let personas = $state<TestPersona[]>([]);
+  let selectedPersonaId = $state<string | null>(null);
+  let selectedPhone = $state<string | null>(null);
+  let showPersonaDialog = $state(false);
+  let messages = $state<any[]>([]);
+  let currentInput = $state("");
+  let conversation = $state<any>(null);
+  let loading = $state(false);
+  let messagesContainer = $state<HTMLDivElement>();
+  let polling: Timer | null = null;
 
-// Replay mode state
-let replayMode = $state(false);
-let replayMetadata = $state<any>(null);
-let editingMessageIndex = $state<number | null>(null);
-let editedContent = $state("");
+  // Replay mode state
+  let replayMode = $state(false);
+  let replayMetadata = $state<any>(null);
+  let editingMessageIndex = $state<number | null>(null);
+  let editedContent = $state("");
 
-async function loadTestConversations() {
-  testConversations = await fetchApi<Conversation[]>(
-    "/api/simulator/conversations",
-  );
-}
-
-async function loadPersonas() {
-  personas = await fetchApi<TestPersona[]>("/api/simulator/personas");
-}
-
-async function loadConversation(phone: string) {
-  const data = await fetchApi<any>(`/api/simulator/conversation/${phone}`);
-  conversation = data.conversation;
-  messages = data.messages;
-  setTimeout(scrollToBottom, 100);
-}
-
-function scrollToBottom() {
-  if (messagesContainer) {
-    messagesContainer.scrollTop = messagesContainer.scrollHeight;
-  }
-}
-
-function openPersonaDialog() {
-  showPersonaDialog = true;
-}
-
-function closePersonaDialog() {
-  showPersonaDialog = false;
-  selectedPersonaId = null;
-}
-
-async function createNewConversation() {
-  loading = true;
-  try {
-    // Auto-generate phone number based on existing count
-    const phoneNumber = `519${String(testConversations.length + 1).padStart(8, "0")}`;
-
-    await fetchApi("/api/simulator/conversations", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ phoneNumber, personaId: selectedPersonaId }),
-    });
-
-    await loadTestConversations();
-    selectedPhone = phoneNumber;
-    closePersonaDialog();
-  } catch (error) {
-    console.error("Failed to create conversation:", error);
-    alert("Error al crear simulación");
-  } finally {
-    loading = false;
-  }
-}
-
-async function deleteConversation(phone: string) {
-  if (!confirm("¿Eliminar esta simulación?")) return;
-
-  loading = true;
-  try {
-    await fetchApi(`/api/simulator/conversations/${phone}`, {
-      method: "DELETE",
-    });
-
-    if (selectedPhone === phone) {
-      selectedPhone = null;
-      messages = [];
-      conversation = null;
-    }
-
-    await loadTestConversations();
-  } catch (error) {
-    console.error("Failed to delete conversation:", error);
-    alert("Error al eliminar simulación");
-  } finally {
-    loading = false;
-  }
-}
-
-async function sendMessage(messageText?: string) {
-  if (!selectedPhone) return;
-
-  const textToSend = messageText || currentInput.trim();
-  if (!textToSend) return;
-
-  loading = true;
-  if (!messageText) currentInput = "";
-
-  messages = [
-    ...messages,
-    {
-      id: Date.now().toString(),
-      direction: "inbound",
-      type: "text",
-      content: textToSend,
-      created_at: new Date().toISOString(),
-    },
-  ];
-
-  setTimeout(scrollToBottom, 50);
-
-  try {
-    await fetchApi("/api/simulator/message", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        phoneNumber: selectedPhone,
-        message: textToSend,
-      }),
-    });
-
-    if (selectedPhone) {
-      setTimeout(() => loadConversation(selectedPhone!), 1000);
-    }
-  } catch (error) {
-    console.error("Send error:", error);
-  } finally {
-    loading = false;
-  }
-}
-
-async function resetConversation() {
-  if (!selectedPhone) return;
-  if (!confirm("¿Reiniciar la conversación?")) return;
-
-  await fetchApi(`/api/simulator/reset/${selectedPhone}`, { method: "POST" });
-  messages = [];
-  conversation = null;
-  replayMode = false;
-  replayMetadata = null;
-  await loadConversation(selectedPhone);
-}
-
-async function loadReplayConversation(sourcePhone: string) {
-  try {
-    // Fetch replay data
-    const replayData = await fetchApi<ReplayData>(
-      `/api/conversations/${sourcePhone}/replay`,
+  async function loadTestConversations() {
+    testConversations = await fetchApi<Conversation[]>(
+      "/api/simulator/conversations",
     );
+  }
 
-    replayMode = true;
-    replayMetadata = replayData.metadata;
+  async function loadPersonas() {
+    personas = await fetchApi<TestPersona[]>("/api/simulator/personas");
+  }
 
-    // Load into simulator backend
-    await fetchApi("/api/simulator/load", {
+  async function loadConversation(phone: string) {
+    const data = await fetchApi<any>(
+      `/api/simulator/conversation/${phone}`,
+    );
+    conversation = data.conversation;
+    messages = data.messages;
+    setTimeout(scrollToBottom, 100);
+  }
+
+  function scrollToBottom() {
+    if (messagesContainer) {
+      messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    }
+  }
+
+  function openPersonaDialog() {
+    showPersonaDialog = true;
+  }
+
+  function closePersonaDialog() {
+    showPersonaDialog = false;
+    selectedPersonaId = null;
+  }
+
+  async function createNewConversation() {
+    loading = true;
+    try {
+      // Auto-generate phone number based on existing count
+      const phoneNumber = `519${String(testConversations.length + 1).padStart(8, "0")}`;
+
+      await fetchApi("/api/simulator/conversations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phoneNumber,
+          personaId: selectedPersonaId,
+        }),
+      });
+
+      await loadTestConversations();
+      selectedPhone = phoneNumber;
+      closePersonaDialog();
+    } catch (error) {
+      console.error("Failed to create conversation:", error);
+      alert("Error al crear simulación");
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function deleteConversation(phone: string) {
+    if (!confirm("¿Eliminar esta simulación?")) return;
+
+    loading = true;
+    try {
+      await fetchApi(`/api/simulator/conversations/${phone}`, {
+        method: "DELETE",
+      });
+
+      if (selectedPhone === phone) {
+        selectedPhone = null;
+        messages = [];
+        conversation = null;
+      }
+
+      await loadTestConversations();
+    } catch (error) {
+      console.error("Failed to delete conversation:", error);
+      alert("Error al eliminar simulación");
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function sendMessage(messageText?: string) {
+    if (!selectedPhone) return;
+
+    const textToSend = messageText || currentInput.trim();
+    if (!textToSend) return;
+
+    loading = true;
+    if (!messageText) currentInput = "";
+
+    messages = [
+      ...messages,
+      {
+        id: Date.now().toString(),
+        direction: "inbound",
+        type: "text",
+        content: textToSend,
+        created_at: new Date().toISOString(),
+      },
+    ];
+
+    setTimeout(scrollToBottom, 50);
+
+    try {
+      await fetchApi("/api/simulator/message", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          phoneNumber: selectedPhone,
+          message: textToSend,
+        }),
+      });
+
+      if (selectedPhone) {
+        setTimeout(() => loadConversation(selectedPhone!), 1000);
+      }
+    } catch (error) {
+      console.error("Send error:", error);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function resetConversation() {
+    if (!selectedPhone) return;
+    if (!confirm("¿Reiniciar la conversación?")) return;
+
+    await fetchApi(`/api/simulator/reset/${selectedPhone}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sourcePhone }),
     });
 
-    // Set to fixed test phone and reload
-    selectedPhone = "51900000001";
-    await loadTestConversations();
+    messages = [];
+    conversation = null;
+    replayMode = false;
+    replayMetadata = null;
     await loadConversation(selectedPhone);
-  } catch (error) {
-    console.error("Failed to load replay:", error);
-    alert("No se pudo cargar la conversación");
-  }
-}
-
-function startEditing(index: number) {
-  const msg = messages[index];
-  if (msg.direction !== "inbound") return;
-
-  editingMessageIndex = index;
-  editedContent = msg.content;
-}
-
-function cancelEditing() {
-  editingMessageIndex = null;
-  editedContent = "";
-}
-
-async function applyEdit(index: number) {
-  if (!selectedPhone) return;
-
-  const originalMsg = messages[index];
-  const newContent = editedContent.trim();
-
-  if (!newContent) {
-    cancelEditing();
-    return;
   }
 
-  if (newContent === originalMsg.content) {
-    cancelEditing();
-    return;
+  async function loadReplayConversation(sourcePhone: string) {
+    try {
+      // Fetch replay data
+      const replayData = await fetchApi<ReplayData>(
+        `/api/conversations/${sourcePhone}/replay`,
+      );
+
+      replayMode = true;
+      replayMetadata = replayData.metadata;
+
+      // Load into simulator backend
+      await fetchApi("/api/simulator/load", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourcePhone }),
+      });
+
+      // Set to fixed test phone and reload
+      selectedPhone = "51900000001";
+      await loadTestConversations();
+      await loadConversation(selectedPhone);
+    } catch (error) {
+      console.error("Failed to load replay:", error);
+      alert("No se pudo cargar la conversación");
+    }
   }
 
-  // Count messages after edit point
-  const futureMessagesCount = messages.length - index - 1;
+  function startEditing(index: number) {
+    const msg = messages[index];
+    if (msg.direction !== "inbound") return;
 
-  if (futureMessagesCount > 0) {
-    const confirmed = confirm(
-      `Editar este mensaje descartará los ${futureMessagesCount} mensajes siguientes. ¿Continuar?`,
-    );
-    if (!confirmed) {
+    editingMessageIndex = index;
+    editedContent = msg.content;
+  }
+
+  function cancelEditing() {
+    editingMessageIndex = null;
+    editedContent = "";
+  }
+
+  async function applyEdit(index: number) {
+    if (!selectedPhone) return;
+
+    const originalMsg = messages[index];
+    const newContent = editedContent.trim();
+
+    if (!newContent) {
       cancelEditing();
       return;
     }
-  }
 
-  loading = true;
-  cancelEditing();
+    if (newContent === originalMsg.content) {
+      cancelEditing();
+      return;
+    }
 
-  try {
-    // Reset conversation
-    await fetchApi(`/api/simulator/reset/${selectedPhone}`, { method: "POST" });
+    // Count messages after edit point
+    const futureMessagesCount = messages.length - index - 1;
 
-    // Replay messages up to and including edit point
-    for (let i = 0; i <= index; i++) {
-      const msg = messages[i];
-      if (msg.direction === "inbound") {
-        const content = i === index ? newContent : msg.content;
-
-        // Send and wait for response
-        await fetchApi("/api/simulator/message", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            phoneNumber: selectedPhone,
-            message: content,
-          }),
-        });
-
-        // Wait between messages to ensure proper processing
-        await new Promise((resolve) => setTimeout(resolve, 500));
+    if (futureMessagesCount > 0) {
+      const confirmed = confirm(
+        `Editar este mensaje descartará los ${futureMessagesCount} mensajes siguientes. ¿Continuar?`,
+      );
+      if (!confirmed) {
+        cancelEditing();
+        return;
       }
     }
 
-    // Reload conversation to see new state
-    await loadConversation(selectedPhone);
-  } catch (error) {
-    console.error("Failed to apply edit:", error);
-    alert("Error al aplicar la edición");
-  } finally {
-    loading = false;
-  }
-}
+    loading = true;
+    cancelEditing();
 
-function handleKeydown(e: KeyboardEvent) {
-  if (e.key === "Enter" && !e.shiftKey) {
-    e.preventDefault();
-    sendMessage();
-  }
-}
+    try {
+      // Reset conversation
+      await fetchApi(`/api/simulator/reset/${selectedPhone}`, {
+        method: "POST",
+      });
 
-function exitReplayMode() {
-  replayMode = false;
-  replayMetadata = null;
-  resetConversation();
-}
+      // Replay messages up to and including edit point
+      for (let i = 0; i <= index; i++) {
+        const msg = messages[i];
+        if (msg.direction === "inbound") {
+          const content = i === index ? newContent : msg.content;
 
-$effect(() => {
-  if (selectedPhone) {
-    loadConversation(selectedPhone);
-  }
-});
+          // Send and wait for response
+          await fetchApi("/api/simulator/message", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              phoneNumber: selectedPhone,
+              message: content,
+            }),
+          });
 
-onMount(() => {
-  // Load personas first
-  loadPersonas();
-
-  // Check if we should load a replay conversation (from server data)
-  if (data.loadPhone) {
-    loadReplayConversation(data.loadPhone);
-  } else {
-    loadTestConversations().then(() => {
-      // Select first conversation if available
-      if (testConversations.length > 0 && !selectedPhone) {
-        selectedPhone = testConversations[0]?.phone_number ?? null;
+          // Wait between messages to ensure proper processing
+          await new Promise((resolve) => setTimeout(resolve, 500));
+        }
       }
-    });
+
+      // Reload conversation to see new state
+      await loadConversation(selectedPhone);
+    } catch (error) {
+      console.error("Failed to apply edit:", error);
+      alert("Error al aplicar la edición");
+    } finally {
+      loading = false;
+    }
   }
 
-  polling = setInterval(() => {
-    loadTestConversations();
-    if (selectedPhone) loadConversation(selectedPhone);
-  }, 2000);
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  }
 
-  return () => {
-    if (polling) clearInterval(polling);
-  };
-});
+  function exitReplayMode() {
+    replayMode = false;
+    replayMetadata = null;
+    resetConversation();
+  }
+
+  $effect(() => {
+    if (selectedPhone) {
+      loadConversation(selectedPhone);
+    }
+  });
+
+  onMount(() => {
+    // Load personas first
+    loadPersonas();
+
+    // Check if we should load a replay conversation (from server data)
+    if (data.loadPhone) {
+      loadReplayConversation(data.loadPhone);
+    } else {
+      loadTestConversations().then(() => {
+        // Select first conversation if available
+        if (testConversations.length > 0 && !selectedPhone) {
+          selectedPhone = testConversations[0]?.phone_number ?? null;
+        }
+      });
+    }
+
+    polling = setInterval(() => {
+      loadTestConversations();
+      if (selectedPhone) loadConversation(selectedPhone);
+    }, 2000);
+
+    return () => {
+      if (polling) clearInterval(polling);
+    };
+  });
 </script>
 
 <PageTitle title="Simulador" />
 
 <div class="flex h-[calc(100vh-65px)] overflow-hidden bg-white">
-	<!-- Conversation list -->
-	<div class="w-full md:w-80 xl:w-96 border-r border-ink-900/10 bg-white flex flex-col shrink-0">
-		<div class="p-6 border-b border-ink-900/10 flex items-center justify-between">
-			<div>
-				<span class="text-xs font-bold tracking-widest uppercase text-ink-400 mb-1 block">
-					Conversaciones de prueba
-				</span>
-				<h2 class="text-2xl font-serif">Simulador</h2>
-			</div>
-			<div class="flex gap-2">
-				{#if data.user.role === 'admin' || data.user.role === 'developer'}
-					<a
-						href="/dashboard/personas"
-						class="w-8 h-8 flex items-center justify-center text-ink-900 hover:bg-ink-50 rounded-full transition-colors"
-						title="Gestionar personas"
-					>
-						<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-							<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-							<circle cx="9" cy="7" r="4"></circle>
-							<path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
-							<path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
-						</svg>
-					</a>
-				{/if}
-				<button
-					onclick={openPersonaDialog}
-					disabled={loading}
-					class="w-8 h-8 flex items-center justify-center text-ink-900 hover:bg-ink-50 rounded-full transition-colors disabled:opacity-50"
-					title="Nueva simulación"
-				>
-					<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-						<line x1="12" y1="5" x2="12" y2="19"></line>
-						<line x1="5" y1="12" x2="19" y2="12"></line>
-					</svg>
-				</button>
-			</div>
-		</div>
+  <!-- Conversation list -->
+  <div
+    class="w-full md:w-80 xl:w-96 border-r border-ink-900/10 bg-white flex flex-col shrink-0"
+  >
+    <div
+      class="p-6 border-b border-ink-900/10 flex items-center justify-between"
+    >
+      <div>
+        <span
+          class="text-xs font-bold tracking-widest uppercase text-ink-400 mb-1 block"
+        >
+          Conversaciones de prueba
+        </span>
+        <h2 class="text-2xl font-serif">Simulador</h2>
+      </div>
+      <div class="flex gap-2">
+        {#if data.user.role === "admin" || data.user.role === "developer"}
+          <a
+            href="/dashboard/personas"
+            class="w-8 h-8 flex items-center justify-center text-ink-900 hover:bg-ink-50 rounded-full transition-colors"
+            title="Gestionar personas"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+              <circle cx="9" cy="7" r="4"></circle>
+              <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+              <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+            </svg>
+          </a>
+        {/if}
+        <button
+          onclick={openPersonaDialog}
+          disabled={loading}
+          class="w-8 h-8 flex items-center justify-center text-ink-900 hover:bg-ink-50 rounded-full transition-colors disabled:opacity-50"
+          title="Nueva simulación"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+        </button>
+      </div>
+    </div>
 
-		<div class="overflow-y-auto flex-1">
-			{#each testConversations as conv (conv.phone_number)}
-				<ConversationItem
-					conversation={conv}
-					isSelected={selectedPhone === conv.phone_number}
-					onclick={() => selectedPhone = conv.phone_number}
-				/>
-			{/each}
+    <div class="overflow-y-auto flex-1">
+      {#each testConversations as conv (conv.phone_number)}
+        <ConversationItem
+          conversation={conv}
+          isSelected={selectedPhone === conv.phone_number}
+          onclick={() => (selectedPhone = conv.phone_number)}
+        />
+      {/each}
 
-			{#if testConversations.length === 0}
-				<div class="p-12 text-center text-ink-300">
-					<p class="font-serif italic">No hay conversaciones de prueba.</p>
-				</div>
-			{/if}
-		</div>
-	</div>
+      {#if testConversations.length === 0}
+        <div class="p-12 text-center text-ink-300">
+          <p class="font-serif italic">
+            No hay conversaciones de prueba.
+          </p>
+        </div>
+      {/if}
+    </div>
+  </div>
 
-	<!-- Conversation detail -->
-	<div class="hidden md:flex flex-col flex-1 bg-cream-100 relative min-w-0">
-		{#if selectedPhone && conversation}
-			<!-- Header -->
-			<div class="px-8 py-6 border-b border-ink-900/10 bg-white/95 backdrop-blur sticky top-0 z-10">
-				<div class="flex justify-between items-center">
-					<div class="space-y-px">
-						<div class="flex items-center gap-3">
-							<h2 class="font-serif text-3xl text-ink-900">
-								{#if conversation.client_name}
-									<span class="text-ink-900">{conversation.client_name}</span>
-									<span class="text-ink-400 text-xl ml-3">{formatPhone(selectedPhone)}</span>
-								{:else}
-									{formatPhone(selectedPhone)}
-								{/if}
-							</h2>
-						{#if replayMode && replayMetadata}
-							<Badge variant="warning" class="text-xs">
-								DEPURACIÓN: {replayMetadata.conversationId} • {replayMetadata.finalState}
-							</Badge>
-						{/if}
-					</div>
+  <!-- Conversation detail -->
+  <div class="hidden md:flex flex-col flex-1 bg-cream-100 relative min-w-0">
+    {#if selectedPhone && conversation}
+      <!-- Header -->
+      <div
+        class="px-8 py-6 border-b border-ink-900/10 bg-white/95 backdrop-blur sticky top-0 z-10"
+      >
+        <div class="flex justify-between items-center">
+          <div class="space-y-px">
+            <div class="flex items-center gap-3">
+              <h2 class="font-serif text-3xl text-ink-900">
+                {#if conversation.client_name}
+                  <span class="text-ink-900">
+                    {conversation.client_name}
+                  </span>
+                  <span class="text-ink-400 text-xl ml-3">
+                    {formatPhone(selectedPhone)}
+                  </span>
+                {:else}
+                  {formatPhone(selectedPhone)}
+                {/if}
+              </h2>
+              {#if replayMode && replayMetadata}
+                <Badge variant="warning" class="text-xs">
+                  DEPURACIÓN: {replayMetadata.conversationId} • {replayMetadata.finalState}
+                </Badge>
+              {/if}
+            </div>
 
-					<!-- Context Data Bar -->
-					<div class="flex items-center gap-4 text-[10px] font-mono uppercase tracking-wider text-ink-500">
-						{#if conversation.persona_id}
-							{@const persona = personas.find(p => p.id === conversation.persona_id)}
-							{#if persona}
-								<div class="flex gap-2">
-									<span class="text-ink-300">Persona:</span>
-									<span class="text-ink-900 font-bold">{persona.segment.toUpperCase()}</span>
-								</div>
-								<div class="w-px h-3 bg-ink-200"></div>
-							{/if}
-						{/if}
-							<div class="flex gap-2">
-								<span class="text-ink-300">Segmento:</span>
-								<span class="text-ink-900 font-bold">{conversation.segment || "—"}</span>
-							</div>
-							<div class="w-px h-3 bg-ink-200"></div>
-							<div class="flex gap-2">
-								<span class="text-ink-300">Crédito:</span>
-								<span class="text-ink-900 font-bold">{conversation.credit_line ? `S/ ${formatPrice(conversation.credit_line)}` : "—"}</span>
-							</div>
-							<div class="w-px h-3 bg-ink-200"></div>
-							<div class="flex gap-2">
-								<span class="text-ink-300">Estado:</span>
-								<span class="text-ink-900 font-bold">{conversation.current_state}</span>
-							</div>
-							<div class="w-px h-3 bg-ink-200"></div>
-							<div class="flex gap-2 items-center">
-								<span class="text-ink-300">Intervención:</span>
-								{#if conversation.status === "human_takeover"}
-									<div class="flex items-center gap-1.5">
-										<span 
-											class="w-1.5 h-1.5 bg-red-500 rounded-full animate-pulse" 
-											title={conversation.handover_reason || "Intervención manual activa"}
-										></span>
-										<span class="text-red-600 font-bold">Activa</span>
-									</div>
-								{:else}
-									<span class="text-ink-900 font-bold">—</span>
-								{/if}
-							</div>
-						</div>
-					</div>
+            <!-- Context data bar -->
+            <div
+              class="flex items-center gap-4 text-[10px] font-mono uppercase tracking-wider text-ink-500"
+            >
+              {#if conversation.persona_id}
+                {@const persona = personas.find(
+                  (p) => p.id === conversation.persona_id,
+                )}
+                {#if persona}
+                  <div class="flex gap-2">
+                    <span class="text-ink-300">Persona:</span>
+                    <span class="text-ink-900 font-bold">
+                      {persona.segment.toUpperCase()}
+                    </span>
+                  </div>
+                  <div class="w-px h-3 bg-ink-200"></div>
+                {/if}
+              {/if}
+              <div class="flex gap-2">
+                <span class="text-ink-300">Segmento:</span>
+                <span class="text-ink-900 font-bold">
+                  {conversation.segment || "—"}
+                </span>
+              </div>
+              <div class="w-px h-3 bg-ink-200"></div>
+              <div class="flex gap-2">
+                <span class="text-ink-300">Crédito:</span>
+                <span class="text-ink-900 font-bold">
+                  {conversation.credit_line
+                    ? `S/ ${formatPrice(conversation.credit_line)}`
+                    : "—"}
+                </span>
+              </div>
+              <div class="w-px h-3 bg-ink-200"></div>
+              <div class="flex gap-2">
+                <span class="text-ink-300">Estado:</span>
+                <span class="text-ink-900 font-bold">
+                  {conversation.current_state}
+                </span>
+              </div>
+              <div class="w-px h-3 bg-ink-200"></div>
+              <div class="flex gap-2 items-center">
+                <span class="text-ink-300">Intervención:</span>
+                {#if conversation.status === "human_takeover"}
+                  <div class="flex items-center gap-1.5">
+                    <span
+                      class="w-1.5 h-1.5 bg-red-500 rounded-full animate-pulse"
+                      title={conversation.handover_reason || "Intervención manual activa"}
+                    ></span>
+                    <span class="text-red-600 font-bold">Activa</span>
+                  </div>
+                {:else}
+                  <span class="text-ink-900 font-bold">—</span>
+                {/if}
+              </div>
+            </div>
+          </div>
 
-					<div class="flex items-center gap-3">
-						{#if replayMode}
-							<Button variant="secondary" onclick={exitReplayMode} class="text-xs py-2">
-								Salir de depuración
-							</Button>
-						{:else}
-							<Button variant="secondary" onclick={resetConversation} class="text-xs py-2">
-								Reiniciar
-							</Button>
-							<Button variant="secondary" onclick={() => deleteConversation(selectedPhone!)} class="text-xs py-2">
-								Eliminar
-							</Button>
-						{/if}
-					</div>
-				</div>
-			</div>
+          <div class="flex items-center gap-3">
+            {#if replayMode}
+              <Button
+                variant="secondary"
+                onclick={exitReplayMode}
+                class="text-xs py-2"
+              >
+                Salir de depuración
+              </Button>
+            {:else}
+              <Button
+                variant="secondary"
+                onclick={resetConversation}
+                class="text-xs py-2"
+              >
+                Reiniciar
+              </Button>
+              <Button
+                variant="secondary"
+                onclick={() =>
+                  deleteConversation(selectedPhone!)}
+                class="text-xs py-2"
+              >
+                Eliminar
+              </Button>
+            {/if}
+          </div>
+        </div>
+      </div>
 
-			<!-- Messages -->
-			<div
-				bind:this={messagesContainer}
-				class="flex-1 overflow-y-auto p-8 space-y-4"
-			>
-				{#if messages.length === 0}
-					<div class="h-full flex items-center justify-center text-ink-300">
-						<p class="font-serif italic">Escribe un mensaje para iniciar la simulación...</p>
-					</div>
-				{/if}
+      <!-- Messages -->
+      <div
+        bind:this={messagesContainer}
+        class="flex-1 overflow-y-auto p-8 space-y-4"
+      >
+        {#if messages.length === 0}
+          <div
+            class="h-full flex items-center justify-center text-ink-300"
+          >
+            <p class="font-serif italic">
+              Escribe un mensaje para iniciar la simulación...
+            </p>
+          </div>
+        {/if}
 
-				{#each messages as msg, i (msg.id)}
-					<div class="space-y-2">
-						{#if editingMessageIndex === i}
-							<div class="bg-amber-50 border border-amber-200 rounded-lg p-4 shadow-sm ml-auto max-w-xl">
-								<div class="flex justify-between items-center mb-2">
-									<span class="text-xs font-bold text-amber-800 uppercase tracking-wider">Editando mensaje</span>
-									<button onclick={cancelEditing} class="text-amber-800 hover:text-amber-900" aria-label="Cancelar edición">
-										<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-											<line x1="18" y1="6" x2="6" y2="18"></line>
-											<line x1="6" y1="6" x2="18" y2="18"></line>
-										</svg>
-									</button>
-								</div>
-								<textarea
-									bind:value={editedContent}
-									class="w-full p-3 border border-amber-300 rounded bg-white font-serif focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500 mb-3 text-ink-900"
-									rows="3"
-									placeholder="Editar mensaje..."
-								></textarea>
-								<div class="flex justify-end gap-2">
-									<Button variant="secondary" onclick={cancelEditing} disabled={loading} class="text-xs">
-										Cancelar
-									</Button>
-									<Button onclick={() => applyEdit(i)} disabled={loading} class="text-xs">
-										{#if loading}
-											<svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-												<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-												<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-											</svg>
-											Aplicando...
-										{:else}
-											Guardar y re-ejecutar
-										{/if}
-									</Button>
-								</div>
-							</div>
-						{:else}
-							<MessageBubble
-								direction={msg.direction}
-								type={msg.type}
-								content={msg.content}
-								createdAt={msg.created_at}
-							>
-								{#snippet actions()}
-									{#if replayMode && msg.direction === "inbound"}
-										<button
-											onclick={() => startEditing(i)}
-											class="bg-white text-ink-600 hover:text-blue-600 p-1.5 rounded-full shadow-sm border border-cream-200 hover:border-blue-200 transition-colors"
-											title="Editar mensaje"
-											disabled={loading}
-										>
-											<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-												<path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path>
-											</svg>
-										</button>
-									{/if}
-								{/snippet}
-							</MessageBubble>
-						{/if}
-					</div>
-				{/each}
-			</div>
+        {#each messages as msg, i (msg.id)}
+          <div class="space-y-2">
+            {#if editingMessageIndex === i}
+              <div
+                class="bg-amber-50 border border-amber-200 rounded-lg p-4 shadow-sm ml-auto max-w-xl"
+              >
+                <div class="flex justify-between items-center mb-2">
+                  <span class="text-xs font-bold text-amber-800 uppercase tracking-wider">
+                    Editando mensaje
+                  </span>
+                  <button
+                    onclick={cancelEditing}
+                    class="text-amber-800 hover:text-amber-900"
+                    aria-label="Cancelar edición"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <line x1="18" y1="6" x2="6" y2="18"></line>
+                      <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                  </button>
+                </div>
+                <textarea
+                  bind:value={editedContent}
+                  class="w-full p-3 border border-amber-300 rounded bg-white font-serif focus:outline-none focus:border-amber-500 focus:ring-1 focus:ring-amber-500 mb-3 text-ink-900"
+                  rows="3"
+                  placeholder="Editar mensaje..."
+                ></textarea>
+                <div class="flex justify-end gap-2">
+                  <Button
+                    variant="secondary"
+                    onclick={cancelEditing}
+                    disabled={loading}
+                    class="text-xs"
+                  >
+                    Cancelar
+                  </Button>
+                  <Button
+                    onclick={() => applyEdit(i)}
+                    disabled={loading}
+                    class="text-xs"
+                  >
+                    {#if loading}
+                      <svg
+                        class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          class="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          stroke-width="4"
+                        ></circle>
+                        <path
+                          class="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        ></path>
+                      </svg>
+                      Aplicando...
+                    {:else}
+                      Guardar y re-ejecutar
+                    {/if}
+                  </Button>
+                </div>
+              </div>
+            {:else}
+              <MessageBubble
+                direction={msg.direction}
+                type={msg.type}
+                content={msg.content}
+                createdAt={msg.created_at}
+                currentUserSide="inbound"
+              >
+                {#snippet actions()}
+                  {#if replayMode && msg.direction === "inbound"}
+                    <button
+                      onclick={() => startEditing(i)}
+                      class="bg-white text-ink-600 hover:text-blue-600 p-1.5 rounded-full shadow-sm border border-cream-200 hover:border-blue-200 transition-colors"
+                      title="Editar mensaje"
+                      disabled={loading}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path
+                          d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"
+                        ></path>
+                      </svg>
+                    </button>
+                  {/if}
+                {/snippet}
+              </MessageBubble>
+            {/if}
+          </div>
+        {/each}
+      </div>
 
-			<!-- Input -->
-			<div class="border-t border-cream-200 p-4 bg-cream-50">
-				<div class="flex gap-4">
-					<input
-						type="text"
-						bind:value={currentInput}
-						onkeydown={handleKeydown}
-						disabled={loading}
-						placeholder="Escribe un mensaje..."
-						class="flex-1 bg-white p-3 border-b border-ink-900/30 font-serif focus:outline-none focus:border-ink-900"
-					/>
-					<Button onclick={() => sendMessage()} disabled={loading || !currentInput.trim()} class="px-4">
-						{#if loading}
-							<svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-								<circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-								<path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-							</svg>
-						{:else}
-							<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-								<line x1="22" y1="2" x2="11" y2="13"></line>
-								<polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-							</svg>
-						{/if}
-					</Button>
-				</div>
-				<p class="text-xs text-ink-400 mt-2 font-mono">
-					Enter para enviar • Shift+Enter para salto de línea
-				</p>
-			</div>
-		{:else}
-			<div class="flex-1 flex flex-col items-center justify-center text-ink-300 opacity-50">
-				<span class="text-9xl mb-4 font-serif italic">&larr;</span>
-				<p class="font-serif text-lg">Seleccione una conversación de prueba.</p>
-			</div>
-		{/if}
-	</div>
+      <!-- Input -->
+      <div class="border-t border-cream-200 p-4 bg-cream-50">
+        <div class="flex gap-4">
+          <input
+            type="text"
+            bind:value={currentInput}
+            onkeydown={handleKeydown}
+            disabled={loading}
+            placeholder="Escribe un mensaje..."
+            class="flex-1 bg-white p-3 border-b border-ink-900/30 font-serif focus:outline-none focus:border-ink-900"
+          />
+          <Button
+            onclick={() => sendMessage()}
+            disabled={loading || !currentInput.trim()}
+            class="px-4"
+          >
+            {#if loading}
+              <svg
+                class="animate-spin h-5 w-5 text-white"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  class="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  stroke-width="4"
+                ></circle>
+                <path
+                  class="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+            {:else}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <line x1="22" y1="2" x2="11" y2="13"></line>
+                <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+              </svg>
+            {/if}
+          </Button>
+        </div>
+        <p class="text-xs text-ink-400 mt-2 font-mono">
+          Enter para enviar • Shift+Enter para salto de línea
+        </p>
+      </div>
+    {:else}
+      <div class="flex-1 flex flex-col items-center justify-center text-ink-300 opacity-50">
+        <span class="text-9xl mb-4 font-serif italic">&larr;</span>
+        <p class="font-serif text-lg">
+          Seleccione una conversación de prueba.
+        </p>
+      </div>
+    {/if}
+  </div>
 </div>
 
 <!-- Persona selection dialog -->
 {#if showPersonaDialog}
-	<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-	<div 
-		class="fixed inset-0 bg-black/50 flex items-center justify-center z-50" 
-		role="dialog"
-		aria-modal="true"
-		tabindex="-1"
-		onclick={closePersonaDialog}
-		onkeydown={(e) => e.key === 'Escape' && closePersonaDialog()}
-	>
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<!-- svelte-ignore a11y_no_static_element_interactions -->
-		<div 
-			class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4" 
-			onclick={(e) => e.stopPropagation()}
-		>
-			<div class="p-6 border-b border-ink-900/10">
-				<h3 class="text-xl font-serif text-ink-900">Nueva conversación</h3>
-				<p class="text-sm text-ink-500 mt-1">Escoge una persona de prueba</p>
-			</div>
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div
+    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onclick={closePersonaDialog}
+    onkeydown={(e) => e.key === "Escape" && closePersonaDialog()}
+  >
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="bg-white rounded-lg shadow-xl max-w-md w-full mx-4"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <div class="p-6 border-b border-ink-900/10">
+        <h3 class="text-xl font-serif text-ink-900">
+          Nueva conversación
+        </h3>
+        <p class="text-sm text-ink-500 mt-1">
+          Escoge una persona de prueba
+        </p>
+      </div>
 
-			<div class="p-6 space-y-2 max-h-96 overflow-y-auto">
-				<button
-					onclick={() => { selectedPersonaId = null; createNewConversation(); }}
-					class="w-full text-left px-4 py-3 border border-ink-900/20 rounded-lg hover:border-ink-900/40 hover:bg-ink-50/50 transition-colors"
-				>
-					<div class="font-medium text-ink-900 mb-0.5">Sin persona</div>
-					<div class="text-xs text-ink-500">Usar proveedores FNB/GASO reales</div>
-				</button>
+      <div class="p-6 space-y-2 max-h-96 overflow-y-auto">
+        <button
+          onclick={() => {
+            selectedPersonaId = null;
+            createNewConversation();
+          }}
+          class="w-full text-left px-4 py-3 border border-ink-900/20 rounded-lg hover:border-ink-900/40 hover:bg-ink-50/50 transition-colors"
+        >
+          <div class="font-medium text-ink-900 mb-0.5">
+            Sin persona
+          </div>
+          <div class="text-xs text-ink-500">
+            Usar proveedores FNB/GASO reales
+          </div>
+        </button>
 
-				{#each personas as persona (persona.id)}
-					<button
-						onclick={() => { selectedPersonaId = persona.id; createNewConversation(); }}
-						class="w-full text-left px-4 py-3 border border-ink-900/20 rounded-lg hover:border-ink-900/40 hover:bg-ink-50/50 transition-colors"
-					>
-						<div class="flex items-center gap-2 mb-0.5">
-							<span class="font-medium text-ink-900">{persona.name}</span>
-							<span class="text-[9px] font-mono font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-ink-100 text-ink-600">
-								{persona.segment}
-							</span>
-						</div>
-						<div class="text-xs text-ink-500">{persona.description}</div>
-					</button>
-				{/each}
-			</div>
+        {#each personas as persona (persona.id)}
+          <button
+            onclick={() => {
+              selectedPersonaId = persona.id;
+              createNewConversation();
+            }}
+            class="w-full text-left px-4 py-3 border border-ink-900/20 rounded-lg hover:border-ink-900/40 hover:bg-ink-50/50 transition-colors"
+          >
+            <div class="flex items-center gap-2 mb-0.5">
+              <span class="font-medium text-ink-900">
+                {persona.name}
+              </span>
+              <span
+                class="text-[9px] font-mono font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-ink-100 text-ink-600"
+              >
+                {persona.segment}
+              </span>
+            </div>
+            <div class="text-xs text-ink-500">
+              {persona.description}
+            </div>
+          </button>
+        {/each}
+      </div>
 
-			<div class="p-6 border-t border-ink-900/10 flex justify-end">
-				<Button variant="secondary" onclick={closePersonaDialog}>
-					Cancelar
-				</Button>
-			</div>
-		</div>
-	</div>
+      <div class="p-6 border-t border-ink-900/10 flex justify-end">
+        <Button variant="secondary" onclick={closePersonaDialog}>
+          Cancelar
+        </Button>
+      </div>
+    </div>
+  </div>
 {/if}
-
-
-
-


### PR DESCRIPTION
Introduce an explicit currentUserSide prop to clarify message ownership and remove implicit direction-based logic in the conversation simulator.

* Add currentUserSide prop to message-bubble and message-thread components and derive isMe from it, replacing direction/isInbound logic.
* Update simulator to pass currentUserSide explicitly for inbound messages to ensure correct alignment and styling.
* Refactor message bubble rendering to consistently rely on isMe for layout and colors.
* Reformat simulator page markup and SVGs for readability and consistency.
* Expand API request payloads into multi-line objects to improve clarity.