### PR TITLE
feat: enforce abortable timeouts and structured error logging for external adapters

### DIFF
--- a/apps/backend/src/adapters/whatsapp/dev-adapter.ts
+++ b/apps/backend/src/adapters/whatsapp/dev-adapter.ts
@@ -1,6 +1,7 @@
 import type { WhatsAppAdapter } from "./types.ts";
 import { createLogger } from "../../lib/logger.ts";
 import { getNotifierUrl, getPublicUrl } from "@totem/utils";
+import { createAbortTimeout, TIMEOUTS } from "../../config/timeouts.ts";
 
 const logger = createLogger("whatsapp");
 
@@ -9,12 +10,17 @@ const publicUrl = getPublicUrl();
 
 export const DevAdapter: WhatsAppAdapter = {
   async sendMessage(to: string, content: string): Promise<string | null> {
+    const { signal, cleanup } = createAbortTimeout(TIMEOUTS.WHATSAPP_SEND);
+
     try {
       const response = await fetch(`${notifierUrl}/send`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phoneNumber: to, content }),
+        signal,
       });
+
+      cleanup();
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -29,9 +35,22 @@ export const DevAdapter: WhatsAppAdapter = {
         status: string;
         messageId?: string;
       };
+
       return data.messageId ?? null;
     } catch (error) {
-      logger.error({ error, to }, "Dev adapter send error");
+      cleanup();
+
+      if (error instanceof Error) {
+        if (error.name === "AbortError") {
+          logger.error(
+            { to, timeoutMs: TIMEOUTS.WHATSAPP_SEND },
+            "Dev adapter send timeout",
+          );
+        } else {
+          logger.error({ error, to }, "Dev adapter send error");
+        }
+      }
+
       return null;
     }
   },
@@ -43,12 +62,17 @@ export const DevAdapter: WhatsAppAdapter = {
   ): Promise<string | null> {
     const imageUrl = `${publicUrl}/media/${imagePath}`;
 
+    const { signal, cleanup } = createAbortTimeout(TIMEOUTS.WHATSAPP_IMAGE);
+
     try {
       const response = await fetch(`${notifierUrl}/send-image`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phoneNumber: to, imageUrl, caption }),
+        signal,
       });
+
+      cleanup();
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -63,9 +87,25 @@ export const DevAdapter: WhatsAppAdapter = {
         status: string;
         messageId?: string;
       };
+
       return data.messageId ?? null;
     } catch (error) {
-      logger.error({ error, to, imagePath }, "Dev adapter image send error");
+      cleanup();
+
+      if (error instanceof Error) {
+        if (error.name === "AbortError") {
+          logger.error(
+            { to, imagePath, timeoutMs: TIMEOUTS.WHATSAPP_IMAGE },
+            "Dev adapter image send timeout",
+          );
+        } else {
+          logger.error(
+            { error, to, imagePath },
+            "Dev adapter image send error",
+          );
+        }
+      }
+
       return null;
     }
   },

--- a/apps/backend/src/config/timeouts.ts
+++ b/apps/backend/src/config/timeouts.ts
@@ -1,0 +1,47 @@
+// Values are in milliseconds
+export const TIMEOUTS = {
+  // Conversation locks
+  LOCK_DEFAULT: 30_000,
+  LOCK_ELIGIBILITY: 60_000,
+
+  // External API calls
+  FNB_AUTH: 10_000,
+  FNB_QUERY: 15_000,
+  POWERBI_QUERY: 20_000,
+
+  // WhatsApp API
+  WHATSAPP_SEND: 10_000,
+  WHATSAPP_IMAGE: 15_000,
+
+  // Notifier service
+  NOTIFIER: 5_000,
+} as const;
+
+/**
+ * Helper to create timeout promise
+ * Usage: Promise.race([operation(), createTimeout(5000, 'Operation')])
+ */
+export function createTimeout(ms: number, operation: string): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => {
+      reject(new Error(`Timeout: ${operation} exceeded ${ms}ms`));
+    }, ms);
+  });
+}
+
+/**
+ * Helper to create AbortController with timeout
+ * Automatically cleans up timer
+ */
+export function createAbortTimeout(ms: number): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), ms);
+
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timeoutId),
+  };
+}

--- a/apps/backend/src/conversation/locks.ts
+++ b/apps/backend/src/conversation/locks.ts
@@ -4,12 +4,15 @@
  */
 
 import { createLogger } from "../lib/logger.ts";
+import { TIMEOUTS } from "../config/timeouts.ts";
 
 const logger = createLogger("locks");
 
 type LockEntry = {
   promise: Promise<void>;
   resolve: () => void;
+  acquiredAt: number;
+  phoneNumber: string;
 };
 
 const locks = new Map<string, LockEntry>();
@@ -31,7 +34,13 @@ export async function acquireLock(phoneNumber: string): Promise<void> {
     resolve = r;
   });
 
-  locks.set(phoneNumber, { promise, resolve: resolve! });
+  locks.set(phoneNumber, {
+    promise,
+    resolve: resolve!,
+    acquiredAt: Date.now(),
+    phoneNumber,
+  });
+
   logger.debug({ phoneNumber }, "Lock acquired");
 }
 
@@ -41,23 +50,94 @@ export async function acquireLock(phoneNumber: string): Promise<void> {
 export function releaseLock(phoneNumber: string): void {
   const entry = locks.get(phoneNumber);
   if (entry) {
+    const duration = Date.now() - entry.acquiredAt;
     locks.delete(phoneNumber);
     entry.resolve();
-    logger.debug({ phoneNumber }, "Lock released");
+    logger.debug({ phoneNumber, durationMs: duration }, "Lock released");
+
+    if (duration > 10_000) {
+      logger.warn(
+        { phoneNumber, durationMs: duration },
+        "Lock held for unusually long time",
+      );
+    }
   }
 }
 
 /**
  * Execute a function with the user lock held
+ *
+ * @param phoneNumber - User phone number (lock key)
+ * @param fn - Function to execute with lock held
+ * @param timeoutMs - Timeout in milliseconds (default: 30s)
+ * @returns Result of fn()
+ * @throws Error if timeout exceeded
  */
 export async function withLock<T>(
   phoneNumber: string,
   fn: () => Promise<T>,
+  timeoutMs: number = TIMEOUTS.LOCK_DEFAULT,
 ): Promise<T> {
   await acquireLock(phoneNumber);
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      reject(new Error(`Lock timeout for ${phoneNumber} after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
   try {
-    return await fn();
+    const result = await Promise.race([fn(), timeoutPromise]);
+    return result;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("Lock timeout")) {
+      logger.error(
+        { error, phoneNumber, timeoutMs },
+        "Lock timeout exceeded - possible stuck operation",
+      );
+    }
+    throw error;
   } finally {
     releaseLock(phoneNumber);
   }
+}
+
+export function getLockStatus(): {
+  activeLocksCount: number;
+  locks: Array<{ phoneNumber: string; heldForMs: number }>;
+} {
+  const now = Date.now();
+  const lockList = Array.from(locks.values()).map((entry) => ({
+    phoneNumber: entry.phoneNumber,
+    heldForMs: now - entry.acquiredAt,
+  }));
+
+  return {
+    activeLocksCount: locks.size,
+    locks: lockList,
+  };
+}
+
+export function cleanupStaleLocks(maxAgeMs: number = 5 * 60_000): number {
+  const now = Date.now();
+  let cleaned = 0;
+
+  for (const [phoneNumber, entry] of locks.entries()) {
+    const age = now - entry.acquiredAt;
+    if (age > maxAgeMs) {
+      logger.warn(
+        { phoneNumber, ageMs: age },
+        "Cleaning up stale lock - possible leaked lock",
+      );
+      locks.delete(phoneNumber);
+      entry.resolve(); // Release any waiters
+      cleaned++;
+    }
+  }
+
+  if (cleaned > 0) {
+    logger.info({ cleaned }, "Cleaned up stale locks");
+  }
+
+  return cleaned;
 }


### PR DESCRIPTION
Introduce a centralized timeout configuration and apply abortable requests across all external service adapters to prevent hanging calls and improve observability.

* Add a shared timeouts configuration with helpers for creating abortable operations.
* Update Notifier, FNB, PowerBI, and WhatsApp adapters to enforce request timeouts via AbortController.
* Ensure timeout resources are always cleaned up after requests.
* Add structured logging for timeouts and external API errors, including operation context and duration.
* Extend lock management to record acquisition timestamps and phone numbers for better traceability.