### PR TITLE
feat(conversation): gate product offers by active catalog context

### DIFF
--- a/apps/backend/src/conversation/handler/command-executor.ts
+++ b/apps/backend/src/conversation/handler/command-executor.ts
@@ -1,17 +1,17 @@
 import type {
-  ConversationPhase,
-  ConversationMetadata,
-  TransitionResult,
   Command,
+  ConversationMetadata,
+  ConversationPhase,
+  TransitionResult,
 } from "@totem/core";
 import { WhatsAppService } from "../../adapters/whatsapp/index.ts";
-import { eventBus, createEvent } from "../../shared/events/index.ts";
-import { sendBundleImages } from "../images.ts";
 import { trackEvent } from "../../domains/analytics/index.ts";
 import { BundleService } from "../../domains/catalog/index.ts";
+import { createLogger } from "../../lib/logger.ts";
+import { createEvent, eventBus } from "../../shared/events/index.ts";
+import { sendBundleImages } from "../images.ts";
 import { getOrCreateConversation, updateConversation } from "../store.ts";
 import { sleep } from "./sleep.ts";
-import { createLogger } from "../../lib/logger.ts";
 
 const logger = createLogger("commands");
 
@@ -174,6 +174,11 @@ async function executeImages(
     } as ConversationPhase;
     const conversation = getOrCreateConversation(phoneNumber);
     updateConversation(phoneNumber, updatedPhase, conversation.metadata);
+  } else {
+    logger.debug(
+      { phoneNumber, category: command.category, query: command.query },
+      "Command executed but no products sent directly (handled by flow logic)",
+    );
   }
 }
 

--- a/apps/backend/src/conversation/handler/enrichment-loop.ts
+++ b/apps/backend/src/conversation/handler/enrichment-loop.ts
@@ -1,16 +1,17 @@
 import type {
-  ConversationPhase,
   ConversationMetadata,
-  TransitionResult,
+  ConversationPhase,
   EnrichmentResult,
+  TransitionResult,
 } from "@totem/core";
-import type { IntelligenceProvider } from "@totem/intelligence";
 import { transition } from "@totem/core";
+import type { IntelligenceProvider } from "@totem/intelligence";
+import type { CatalogSnapshot } from "@totem/types";
 import { createTraceId } from "@totem/utils";
+import { createLogger } from "../../lib/logger.ts";
 import { enrichmentRegistry } from "../enrichment/index.ts";
 import { applyEnrichmentToMetadata } from "../enrichment/metadata-manager.ts";
 import { updateConversation } from "../store.ts";
-import { createLogger } from "../../lib/logger.ts";
 
 const logger = createLogger("enrichment");
 const MAX_ENRICHMENT_LOOPS = 10; // Safety limit
@@ -34,6 +35,7 @@ export async function runEnrichmentLoop(
     type: string;
     timestamp: number;
   },
+  context?: CatalogSnapshot,
 ): Promise<TransitionResult> {
   let currentPhase = phase;
   let enrichment: EnrichmentResult | undefined;
@@ -48,6 +50,7 @@ export async function runEnrichmentLoop(
       metadata,
       enrichment,
       quotedContext,
+      context,
     });
 
     if (result.type !== "need_enrichment") {

--- a/apps/backend/src/domains/catalog/products.ts
+++ b/apps/backend/src/domains/catalog/products.ts
@@ -98,4 +98,25 @@ export const ProductService = {
     );
     return rows.map((r) => r.category);
   },
+
+  /**
+   * Get all active brands from products involved in active, in-stock bundles.
+   */
+  getActiveBrands: (): string[] => {
+    const rows = getAll<{ brand: string }>(
+      `SELECT DISTINCT p.brand
+       FROM catalog_bundles b
+       JOIN catalog_periods p_desc ON b.period_id = p_desc.id,
+            json_tree(b.composition_json) as ref
+       JOIN products p ON p.id = ref.value
+       WHERE p_desc.status = 'active'
+         AND b.is_active = 1
+         AND b.stock_status != 'out_of_stock'
+         AND ref.key = 'id'
+         AND p.brand IS NOT NULL
+         AND p.brand != ''
+       ORDER BY p.brand`,
+    );
+    return rows.map((r) => r.brand);
+  },
 };

--- a/packages/core/src/conversation/phases/offering-products.test.ts
+++ b/packages/core/src/conversation/phases/offering-products.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "bun:test";
+import { transitionOfferingProducts } from "./offering-products.ts";
+import type { ConversationMetadata } from "../types.ts";
+import type { CatalogSnapshot } from "@totem/types";
+
+describe("Offering Products Phase - Context Projection", () => {
+  const mockPhase: any = {
+    phase: "offering_products",
+    lastShownCategory: "celulares",
+    sentProducts: [],
+  };
+
+  const mockMetadata: ConversationMetadata = {
+    createdAt: Date.now(),
+    lastActivityAt: Date.now(),
+  };
+
+  test("should send images when brand IS in context", () => {
+    const context: CatalogSnapshot = {
+      activeBrands: ["Samsung", "Apple"],
+      activeCategories: ["celulares"],
+    };
+
+    const result = transitionOfferingProducts(
+      mockPhase,
+      "Quiero un Samsung",
+      mockMetadata,
+      undefined,
+      undefined,
+      context,
+    );
+
+    expect(result.type).toBe("update");
+    if (result.type === "update") {
+      const sendImages = result.commands.find((c) => c.type === "SEND_IMAGES");
+      expect(sendImages).toBeDefined();
+      expect((sendImages as any).query).toBe("samsung");
+    }
+  });
+
+  test("should BLOCK images when brand is NOT in context", () => {
+    const context: CatalogSnapshot = {
+      activeBrands: ["Samsung", "Apple"],
+      activeCategories: ["celulares"],
+    };
+
+    const result = transitionOfferingProducts(
+      mockPhase,
+      "Quiero un Tecno",
+      mockMetadata,
+      undefined,
+      undefined,
+      context,
+    );
+
+    if (result.type === "update") {
+      const sendImages = result.commands.find((c) => c.type === "SEND_IMAGES");
+      if (sendImages) {
+        expect((sendImages as any).query).not.toContain("tecno");
+      }
+    } else {
+      expect(result.type).toBe("need_enrichment");
+    }
+  });
+});

--- a/packages/core/src/conversation/transition.ts
+++ b/packages/core/src/conversation/transition.ts
@@ -44,6 +44,7 @@ export function transition(input: TransitionInput): TransitionResult {
         metadata,
         enrichment,
         quotedContext,
+        input.context,
       );
 
     case "handling_objection":

--- a/packages/core/src/conversation/types.ts
+++ b/packages/core/src/conversation/types.ts
@@ -1,4 +1,9 @@
-import type { Segment, Bundle, CategoryGroup } from "@totem/types";
+import type {
+  Segment,
+  Bundle,
+  CategoryGroup,
+  CatalogSnapshot,
+} from "@totem/types";
 import type { DomainEvent } from "@totem/types";
 
 export type ConversationPhase =
@@ -197,4 +202,5 @@ export type TransitionInput = {
     type: string;
     timestamp: number;
   };
+  context?: CatalogSnapshot;
 };

--- a/packages/core/src/matching/product-selection.ts
+++ b/packages/core/src/matching/product-selection.ts
@@ -171,11 +171,11 @@ export function extractProductIntent(
   // 3. Validate if the remaining text looks like a product specifier
   // Common brands/models we expect (not exhaustive, just heuristic)
   const isLikelyProduct =
-    /(iphone|samsung|galaxy|xiaomi|redmi|motorola|moto|honor|huawei|zte|oppo|vivo|realme|infinix|tecno|nokia|lg|sony|pixel|pro|max|ultra|plus|lite|note)/.test(
+    /(iphone|samsung|galaxy|xiaomi|redmi|motorola|moto|honor|huawei|zte|oppo|vivo|realme|infinix|tecno|nokia|lg|sony|pixel|pro|max|ultra|plus|lite|note)\b/.test(
       cleanQuery,
     ) ||
     // Or it has alphanumeric structure like "a14", "s23", "15 pro"
-    /[a-z]+[0-9]+|[0-9]+[a-z]+/.test(cleanQuery);
+    /\b([a-z]+[0-9]+|[0-9]+[a-z]+)\b/.test(cleanQuery);
 
   if (hasIntent && isLikelyProduct) {
     return { type: "specific", query: cleanQuery };

--- a/packages/types/src/catalog.ts
+++ b/packages/types/src/catalog.ts
@@ -211,3 +211,9 @@ export type Bundle = {
   created_at: string;
   updated_at: string;
 };
+
+/** Snapshot of active catalog state for context projection */
+export type CatalogSnapshot = {
+  activeBrands: string[];
+  activeCategories: string[];
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,6 +18,7 @@ export type {
   CategoryConfig,
   CategoryKey,
   CategoryGroup,
+  CatalogSnapshot,
 } from "./catalog.ts";
 export { CATEGORIES, CATEGORY_GROUPS } from "./catalog.ts";
 


### PR DESCRIPTION
Introduce catalog context projection into the product offering phase so product suggestions are constrained to brands and categories that are currently active and in stock.

The backend now derives a catalog snapshot (active brands and categories) from the product service and threads it through the conversation orchestrator, enrichment loop, and phase transition logic. The offering-products phase uses this context to block suggestions and images for brands that are not available in the current catalog.

Additional changes include improved product intent matching, minor logging and import cleanup, and new tests verifying that unavailable brands are correctly rejected during the offering phase.